### PR TITLE
Modify octo for vggt finetuning

### DIFF
--- a/VGGT_FINETUNING_README.md
+++ b/VGGT_FINETUNING_README.md
@@ -1,0 +1,155 @@
+# VGGT Finetuning Setup for Octo
+
+This README explains the modifications made to enable finetuning Octo models with VGGT-preprocessed datasets.
+
+## What Was Modified
+
+### 1. Updated `octo/scripts/finetune.py`
+
+- **TFDS Builders**: Added custom TFDS builders for VGGT datasets:
+  - `LiberoObjectVggt`
+  - `LiberoSpatialVggt` 
+  - `LiberoGoalVggt`
+  - `LiberoO10Vggt` / `LiberO10Vggt` (handles the typo in the original dataset)
+
+- **Configuration Handling**: Enhanced config merging to support:
+  - `update_config`: Updates specific parts of the pretrained model config
+  - `config_delete_keys`: Removes conflicting keys from pretrained config
+
+### 2. Created `octo/scripts/configs/finetune_vggt_config.py`
+
+- **Dataset Configuration**: Configured for your VGGT datasets in `/workspace/libero_vggt_datasets2`
+- **Model Configuration**: Set up to use both VGGT tokens and image tokenizers
+- **Training Parameters**: Optimized for VGGT finetuning
+
+### 3. Created Launch Script `run_vggt_finetune.sh`
+
+A convenience script to run finetuning with proper parameters.
+
+## Dataset Structure Expected
+
+Your VGGT datasets should have this structure:
+```
+/workspace/libero_vggt_datasets2/
+├── libero_object_vggt/
+│   └── 1.0.0/
+│       ├── dataset_info.json
+│       ├── features.json
+│       └── *.tfrecord files
+├── libero_spatial_vggt/
+├── libero_goal_vggt/
+└── liber_o10_vggt/  # Note the typo
+```
+
+Each dataset should contain episodes with:
+- **observations**: `image`, `proprio`, `vggt_tokens` (shape: 261, 2048, dtype: float16)
+- **actions**: 7-dimensional action vectors
+- **episode_metadata**: task descriptions and file paths
+
+## How to Use
+
+### 1. Update Paths in Config
+
+Edit `octo/scripts/configs/finetune_vggt_config.py` and update:
+```python
+"data_dir": "/path/to/your/vggt/datasets",  # Update this path
+```
+
+### 2. Update Launch Script
+
+Edit `run_vggt_finetune.sh` and set:
+```bash
+PRETRAINED_PATH="/path/to/pretrained/octo/model"
+PRETRAINED_STEP=1000000  # Or whatever step you want
+SAVE_DIR="/path/to/save/finetuned/models"
+WANDB_ENTITY="your_wandb_username"
+```
+
+### 3. Run Finetuning
+
+```bash
+chmod +x run_vggt_finetune.sh
+./run_vggt_finetune.sh
+```
+
+### 4. Manual Run (Alternative)
+
+```bash
+cd octo/scripts
+python finetune.py \
+    --name "vggt_libero_experiment" \
+    --config.pretrained_path="/path/to/pretrained/model" \
+    --config.pretrained_step=1000000 \
+    --config.save_dir="/path/to/save/dir" \
+    --config.wandb.project="octo_vggt_finetune" \
+    --config.wandb.entity="your_entity"
+```
+
+## Key Configuration Options
+
+The config supports several important settings:
+
+### Model Architecture
+- **VGGT Tokenizer**: Processes pre-computed VGGT tokens
+- **Image Tokenizer**: Processes raw images (for mixed vision approaches)
+- **Mixed Vision**: Can use both VGGT and patch tokens simultaneously
+
+### Training Settings
+- **Finetuning Mode**: `full`, `head_only`, or `head_mlp_only`
+- **Task Mode**: `image_conditioned`, `language_conditioned`, or `multimodal`
+- **Batch Size**: Default 8, adjust based on GPU memory
+- **Learning Rate**: Cosine schedule with warmup
+
+### Data Settings
+- **Window Size**: Temporal window for observations/actions
+- **Action Horizon**: Future action prediction length
+- **Data Augmentation**: Configurable image augmentations
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Dataset Not Found**: Ensure TFDS builders are properly registered by importing `finetune.py`
+2. **VGGT Tokens Missing**: Check that your datasets actually contain `vggt_tokens` in observations
+3. **Shape Mismatches**: Verify VGGT tokens have shape (261, 2048) and dtype float16
+4. **Memory Issues**: Reduce batch size or use gradient accumulation
+
+### Debugging Dataset Loading
+
+Run this to test dataset loading:
+```python
+import tensorflow_datasets as tfds
+import sys
+sys.path.append('octo/scripts')
+import finetune  # Register builders
+
+builder = tfds.builder('libero_object_vggt', data_dir='/workspace/libero_vggt_datasets2')
+ds = builder.as_dataset(split='train[:1]')
+for episode in ds.take(1):
+    steps = list(episode['steps'])
+    print(f"Found {len(steps)} steps")
+    if steps:
+        obs = steps[0]['observation']
+        print(f"Observation keys: {list(obs.keys())}")
+        if 'vggt_tokens' in obs:
+            print(f"VGGT tokens shape: {obs['vggt_tokens'].shape}")
+```
+
+## Model Architecture Details
+
+The finetuning setup uses:
+
+1. **VGGT Tokenizer**: Directly processes pre-computed VGGT tokens
+2. **Image Tokenizer**: Processes raw images with patch encoder
+3. **Mixed Vision**: Both tokenizers feed into the transformer
+4. **Action Head**: Predicts robot actions from fused representations
+
+This allows the model to leverage both the rich VGGT representations and fine-grained image patches for robust manipulation policies.
+
+## Next Steps
+
+After finetuning:
+1. **Evaluation**: Use the finetuned model for robot evaluation
+2. **Analysis**: Compare VGGT vs standard image finetuning performance
+3. **Ablation**: Test different VGGT integration strategies
+4. **Deployment**: Use finetuned models for real robot control

--- a/octo/scripts/configs/finetune_vggt_config.py
+++ b/octo/scripts/configs/finetune_vggt_config.py
@@ -1,0 +1,187 @@
+from ml_collections import ConfigDict
+from ml_collections.config_dict import FieldReference, placeholder
+
+from octo.utils.spec import ModuleSpec
+from octo.model.components.tokenizers import VGGTTokenizer, VisionMixer, ImageTokenizer
+from octo.model.components.vit_encoders import PatchEncoder
+
+
+def get_config(config_string="full,multimodal"):
+    mode, task = config_string.split(",")
+    assert task in ["image_conditioned", "language_conditioned", "multimodal"]
+    assert mode in ["full", "head_only", "head_mlp_only"]
+
+    # Configuration for VGGT datasets
+    VGGT_DATASET_KWARGS_LIST = [
+        {
+            "name": "libero_object_vggt",
+            "data_dir": "/workspace/libero_vggt_datasets2",  # Update this to your actual path
+            "image_obs_keys": {"primary": "image"},
+            "proprio_obs_key": "proprio",
+            "language_key": None,  # Set if you have language instructions
+            "action_proprio_normalization_type": "normal",
+            "action_normalization_mask": [True, True, True, True, True, True, False],
+            "standardize_fn": None,  # No standardization needed since data is already processed
+        },
+        {
+            "name": "libero_spatial_vggt", 
+            "data_dir": "/workspace/libero_vggt_datasets2",
+            "image_obs_keys": {"primary": "image"},
+            "proprio_obs_key": "proprio",
+            "language_key": None,
+            "action_proprio_normalization_type": "normal",
+            "action_normalization_mask": [True, True, True, True, True, True, False],
+            "standardize_fn": None,
+        },
+        {
+            "name": "libero_goal_vggt",
+            "data_dir": "/workspace/libero_vggt_datasets2", 
+            "image_obs_keys": {"primary": "image"},
+            "proprio_obs_key": "proprio",
+            "language_key": None,
+            "action_proprio_normalization_type": "normal",
+            "action_normalization_mask": [True, True, True, True, True, True, False],
+            "standardize_fn": None,
+        },
+        {
+            "name": "liber_o10_vggt",  # Note: this matches the typo in the original dataset
+            "data_dir": "/workspace/libero_vggt_datasets2",
+            "image_obs_keys": {"primary": "image"},
+            "proprio_obs_key": "proprio", 
+            "language_key": None,
+            "action_proprio_normalization_type": "normal",
+            "action_normalization_mask": [True, True, True, True, True, True, False],
+            "standardize_fn": None,
+        },
+    ]
+
+    if mode == "full":
+        frozen_keys = None
+    elif mode == "head_only":
+        frozen_keys = ("octo_transformer.*",)
+    elif mode == "head_mlp_only":
+        frozen_keys = (
+            "octo_transformer.*",
+            "heads_*.map_head.probe",
+            "heads_*.map_head.MultiHeadDotProductAttention_0.*",
+        )
+    else:
+        raise ValueError("Invalid mode")
+
+    max_steps = FieldReference(50000)
+    window_size = FieldReference(default=1)
+
+    config = dict(
+        pretrained_path=placeholder(str),
+        pretrained_step=placeholder(int),
+        batch_size=8,
+        shuffle_buffer_size=10000,
+        num_steps=max_steps,
+        log_interval=100,
+        eval_interval=5000,
+        save_interval=5000,
+        save_dir=placeholder(str),
+        seed=42,
+        wandb=dict(
+            project="octo_vggt_finetune", group=placeholder(str), entity=placeholder(str)
+        ),
+        dataset_kwargs_list=VGGT_DATASET_KWARGS_LIST,
+        modality=task,
+        finetuning_mode=mode,
+        window_size=window_size,
+        optimizer=dict(
+            learning_rate=dict(
+                name="cosine",
+                init_value=0.0,
+                peak_value=3e-4,
+                warmup_steps=2000,
+                decay_steps=max_steps,
+                end_value=0.0,
+            ),
+            weight_decay=0.01,
+            clip_gradient=1.0,
+            frozen_keys=frozen_keys,
+            grad_accumulation_steps=None,
+        ),
+        val_kwargs=dict(
+            val_shuffle_buffer_size=1000,
+            num_val_batches=16,
+        ),
+        viz_kwargs=dict(
+            eval_batch_size=128,
+            trajs_for_metrics=100,
+            trajs_for_viz=8,
+            samples_per_state=8,
+        ),
+    )
+
+    if task == "image_conditioned":
+        goal_relabeling_strategy = "uniform"
+        keep_image_prob = 1.0
+    elif task == "language_conditioned":
+        goal_relabeling_strategy = None
+        keep_image_prob = 0.0
+    elif task == "multimodal":
+        goal_relabeling_strategy = "uniform"
+        keep_image_prob = 0.5
+    else:
+        raise ValueError("Invalid modality")
+
+    traj_transform_kwargs = dict(
+        window_size=window_size,
+        action_horizon=4,
+        goal_relabeling_strategy=goal_relabeling_strategy,
+        task_augment_strategy="delete_task_conditioning",
+        task_augment_kwargs=dict(
+            keep_image_prob=keep_image_prob,
+        ),
+    )
+    
+    workspace_augment_kwargs = dict(
+        random_resized_crop=dict(scale=[0.8, 1.0], ratio=[0.9, 1.1]),
+        random_brightness=[0.1],
+        random_contrast=[0.9, 1.1],
+        random_saturation=[0.9, 1.1],
+        random_hue=[0.05],
+        augment_order=[
+            "random_resized_crop",
+            "random_brightness",
+            "random_contrast",
+            "random_saturation",
+            "random_hue",
+        ],
+    )
+    
+    frame_transform_kwargs = dict(
+        resize_size={
+            "primary": (224, 224),  # Match VGGT input size
+        },
+        image_augment_kwargs=dict(
+            primary=workspace_augment_kwargs,
+        ),
+    )
+    
+    config["frame_transform_threads"] = 16
+    config["traj_transform_kwargs"] = traj_transform_kwargs
+    config["frame_transform_kwargs"] = frame_transform_kwargs
+
+    # Model configuration update for VGGT tokens
+    config['update_config'] = {
+        "model": {
+            "observation_tokenizers": {
+                "vggt_tokens": ModuleSpec.create(VGGTTokenizer),
+                # Keep the primary image tokenizer for mixed vision
+                "image_primary": ModuleSpec.create(
+                    ImageTokenizer,
+                    encoder=ModuleSpec.create(
+                        PatchEncoder,
+                        patch_size=16,
+                        num_features=512
+                    ),
+                    obs_stack_keys=("image_primary",),
+                ),
+            }
+        }
+    }
+
+    return ConfigDict(config)

--- a/run_vggt_finetune.sh
+++ b/run_vggt_finetune.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Script to run VGGT finetuning
+# Make sure to update the paths and parameters according to your setup
+
+# Set environment variables
+export CUDA_VISIBLE_DEVICES=0  # Update this to use the appropriate GPU
+
+# Update these paths according to your setup:
+PRETRAINED_PATH="/path/to/pretrained/octo/model"  # Update this path
+PRETRAINED_STEP=1000000  # Update this step number
+SAVE_DIR="/workspace/vggt_finetuned_models"  # Update this path
+WANDB_PROJECT="octo_vggt_finetune"
+WANDB_GROUP="libero_experiments"
+WANDB_ENTITY="your_wandb_entity"  # Update this
+
+echo "Starting VGGT finetuning..."
+echo "Make sure to update the paths in this script before running!"
+
+# Create save directory if it doesn't exist
+mkdir -p "$SAVE_DIR"
+
+# Run the finetuning
+cd octo/scripts
+
+python finetune.py \
+    --name "vggt_libero_finetune" \
+    --config.pretrained_path="$PRETRAINED_PATH" \
+    --config.pretrained_step=$PRETRAINED_STEP \
+    --config.save_dir="$SAVE_DIR" \
+    --config.wandb.project="$WANDB_PROJECT" \
+    --config.wandb.group="$WANDB_GROUP" \
+    --config.wandb.entity="$WANDB_ENTITY" \
+    --config.batch_size=4 \
+    --config.num_steps=25000 \
+    --config.log_interval=100 \
+    --config.eval_interval=2500 \
+    --config.save_interval=2500
+
+echo "Finetuning complete!"


### PR DESCRIPTION
Enable finetuning Octo models with VGGT-preprocessed datasets by extending the data loading and model configuration.

The standard Octo finetuning pipeline expects a different dataset structure (without VGGT tokens). This PR introduces custom TFDS builders and a new configuration to properly load and utilize pre-computed VGGT tokens alongside image observations, allowing for multi-modal finetuning.