### PR TITLE
Fix dataset statistics argument passing

### DIFF
--- a/FIXES_SUMMARY.md
+++ b/FIXES_SUMMARY.md
@@ -1,0 +1,113 @@
+# Fixes Applied for OOM and Dataset Statistics Issues
+
+## Issue Analysis
+
+You encountered two main issues:
+
+1. **OOM (Out of Memory) Error**: The original training was crashing due to memory issues when computing statistics for multiple datasets simultaneously.
+
+2. **Multiple Keyword Argument Error**: After creating the unified statistics file, you got this error:
+   ```
+   TypeError: octo.data.dataset.make_dataset_from_rlds() got multiple values for keyword argument 'dataset_statistics'
+   ```
+
+## Root Cause
+
+The error occurred in `/workspace/octo/octo/data/dataset.py` in the `make_interleaved_dataset` function. The issue was:
+
+1. You correctly configured your `config_offline.py` to pass the unified statistics file path via `"dataset_statistics": UNIFIED_STATS_PATH`
+2. However, the `make_interleaved_dataset` function was trying to pass the `dataset_statistics` parameter twice:
+   - Once from your config (lines 569)
+   - Once explicitly as a separate parameter (line 573)
+
+This caused the "multiple values for keyword argument" error.
+
+## Fixes Applied
+
+### 1. Fixed the Multiple Parameter Issue
+
+**File**: `/workspace/octo/octo/data/dataset.py`
+**Lines**: 561-574
+
+**Before**:
+```python
+dataset, _ = make_dataset_from_rlds(
+    **dataset_kwargs,
+    train=train,
+    num_parallel_calls=threads,
+    num_parallel_reads=reads,
+    dataset_statistics=all_dataset_statistics[dataset_kwargs["name"]],
+)
+```
+
+**After**:
+```python
+# Create a copy of dataset_kwargs to avoid modifying the original
+dataset_kwargs_copy = dict(dataset_kwargs)
+
+# Only add dataset_statistics if it's not already present in the kwargs
+if "dataset_statistics" not in dataset_kwargs_copy:
+    dataset_kwargs_copy["dataset_statistics"] = all_dataset_statistics[dataset_kwargs["name"]]
+
+dataset, _ = make_dataset_from_rlds(
+    **dataset_kwargs_copy,
+    train=train,
+    num_parallel_calls=threads,
+    num_parallel_reads=reads,
+)
+```
+
+This fix ensures that if `dataset_statistics` is already provided in the config (like your unified stats file), it won't be overridden or duplicated.
+
+### 2. Enhanced the Unified Statistics Script
+
+**File**: `/workspace/octo/scripts/create_unified_statistics.py`
+
+**Issue**: Your original script was missing the `p99` and `p01` quantiles that the normalization code expects.
+
+**Fix**: Added computation of quantiles to match the expected format from `get_dataset_statistics()`:
+
+```python
+# Compute quantiles
+action_p99 = np.quantile(all_actions, 0.99, 0)
+action_p01 = np.quantile(all_actions, 0.01, 0)
+proprio_p99 = np.quantile(all_proprios, 0.99, 0)
+proprio_p01 = np.quantile(all_proprios, 0.01, 0)
+
+final_statistics = {
+    'action': {
+        'mean': action_stats['mean'].tolist(),
+        'std': action_stats['std'].tolist(),
+        'max': action_stats['max'].tolist(),
+        'min': action_stats['min'].tolist(),
+        'p99': action_p99.tolist(),
+        'p01': action_p01.tolist(),
+    },
+    'proprio': {
+        'mean': prop_stats['mean'].tolist(),
+        'std': prop_stats['std'].tolist(),
+        'max': prop_stats['max'].tolist(),
+        'min': prop_stats['min'].tolist(),
+        'p99': proprio_p99.tolist(),
+        'p01': proprio_p01.tolist(),
+    },
+    'num_transitions': num_transitions,
+    'num_trajectories': num_trajectories,
+}
+```
+
+## Next Steps
+
+1. **Regenerate the unified statistics file**: Run your updated `create_unified_statistics.py` script to create a new unified statistics file with the correct format including quantiles.
+
+2. **Test the training**: Try running `finetune.py` again with your `config_offline.py` that points to the new unified statistics file.
+
+3. **Your approach is sound**: Using a pre-computed unified statistics file is the right solution for avoiding OOM errors when training on multiple large datasets.
+
+## Why This Approach Works
+
+- **Memory Efficiency**: Pre-computing statistics avoids loading all datasets into memory simultaneously during training
+- **Consistent Normalization**: All datasets use the same normalization parameters, which is good for training stability
+- **Faster Training Startup**: No need to compute statistics on each training run
+
+The fixes ensure your unified statistics approach works correctly with the existing Octo codebase.

--- a/octo/octo/data/dataset.py
+++ b/octo/octo/data/dataset.py
@@ -565,12 +565,18 @@ def make_interleaved_dataset(
         threads_per_dataset,
         reads_per_dataset,
     ):
+        # Create a copy of dataset_kwargs to avoid modifying the original
+        dataset_kwargs_copy = dict(dataset_kwargs)
+        
+        # Only add dataset_statistics if it's not already present in the kwargs
+        if "dataset_statistics" not in dataset_kwargs_copy:
+            dataset_kwargs_copy["dataset_statistics"] = all_dataset_statistics[dataset_kwargs["name"]]
+        
         dataset, _ = make_dataset_from_rlds(
-            **dataset_kwargs,
+            **dataset_kwargs_copy,
             train=train,
             num_parallel_calls=threads,
             num_parallel_reads=reads,
-            dataset_statistics=all_dataset_statistics[dataset_kwargs["name"]],
         )
         dataset = apply_trajectory_transforms(
             dataset.repeat(),

--- a/octo/scripts/create_unified_statistics.py
+++ b/octo/scripts/create_unified_statistics.py
@@ -85,9 +85,50 @@ def main():
     del action_stats['M2']
     del prop_stats['M2']
     
+    # Need to compute quantiles from the data
+    print("Computing quantiles...")
+    
+    # We need to iterate through the dataset again to collect all data for quantile computation
+    all_actions = []
+    all_proprios = []
+    
+    raw_dataset = tf.data.TFRecordDataset(TFRECORD_FILES)
+    for raw_record in tqdm(raw_dataset):
+        example = tf.io.parse_single_example(raw_record, FEATURE_DESCRIPTION)
+        
+        actions = tf.reshape(tf.sparse.to_dense(example[ACTION_KEY]), [-1, action_dim])
+        proprios = tf.reshape(tf.sparse.to_dense(example[PROP_KEY]), [-1, proprio_dim])
+        
+        all_actions.append(actions.numpy())
+        all_proprios.append(proprios.numpy())
+    
+    # Concatenate all data
+    all_actions = np.concatenate(all_actions, axis=0)
+    all_proprios = np.concatenate(all_proprios, axis=0)
+    
+    # Compute quantiles
+    action_p99 = np.quantile(all_actions, 0.99, 0)
+    action_p01 = np.quantile(all_actions, 0.01, 0)
+    proprio_p99 = np.quantile(all_proprios, 0.99, 0)
+    proprio_p01 = np.quantile(all_proprios, 0.01, 0)
+
     final_statistics = {
-        'action': {key: val.tolist() if isinstance(val, np.ndarray) else val for key, val in action_stats.items()},
-        'proprio': {key: val.tolist() if isinstance(val, np.ndarray) else val for key, val in prop_stats.items()},
+        'action': {
+            'mean': action_stats['mean'].tolist(),
+            'std': action_stats['std'].tolist(),
+            'max': action_stats['max'].tolist(),
+            'min': action_stats['min'].tolist(),
+            'p99': action_p99.tolist(),
+            'p01': action_p01.tolist(),
+        },
+        'proprio': {
+            'mean': prop_stats['mean'].tolist(),
+            'std': prop_stats['std'].tolist(),
+            'max': prop_stats['max'].tolist(),
+            'min': prop_stats['min'].tolist(),
+            'p99': proprio_p99.tolist(),
+            'p01': proprio_p01.tolist(),
+        },
         'num_transitions': num_transitions,  # ADDED: Save counts to the final JSON
         'num_trajectories': num_trajectories, # ADDED: Save counts to the final JSON
     }


### PR DESCRIPTION
Fix `TypeError` with pre-computed dataset statistics and ensure their format is complete.

The `TypeError` arose from `dataset_statistics` being redundantly passed to `make_dataset_from_rlds`. This PR resolves that by preventing duplicate arguments. It also updates `create_unified_statistics.py` to include `p99` and `p01` quantiles, ensuring the pre-computed statistics meet the full requirements for normalization and thus preventing OOM issues during training.

---
<a href="https://cursor.com/background-agent?bcId=bc-b6704a50-0b60-41a2-9587-0ffdc85ebe6f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b6704a50-0b60-41a2-9587-0ffdc85ebe6f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>