### PR TITLE
Debug Octo finetuning stability

### DIFF
--- a/octo/scripts/configs/config_offline.py
+++ b/octo/scripts/configs/config_offline.py
@@ -69,7 +69,7 @@ def get_config(config_string="full,multimodal"):
     ]
     
     total_steps = 150000
-    stage1_steps = 5000
+    stage1_steps = 2000  # Reduced from 5000 for simpler transition
 
     if mode == "full":
        frozen_keys = None
@@ -89,10 +89,10 @@ def get_config(config_string="full,multimodal"):
         pretrained_path=placeholder(str),
         pretrained_step=placeholder(int),
         batch_size=4,
-        shuffle_buffer_size=100,
+        shuffle_buffer_size=500,  # Increased for better data diversity
         num_steps=total_steps,
         log_interval=100, # was 100
-        eval_interval=5000, # was 5000
+        eval_interval=2500, # More frequent validation to catch issues early
         save_interval=5000, # was 5000
         save_dir=placeholder(str),
         seed=42,
@@ -108,14 +108,14 @@ def get_config(config_string="full,multimodal"):
             learning_rate=dict(
                 name="cosine",
                 init_value=0.0,
-                peak_value=1e-5,
+                peak_value=3e-6,  # More conservative but not too small
                 warmup_steps=5000,
                 decay_steps=max_steps,
                 end_value=0.0,
             ),
             grad_accumulation_steps=16,
             weight_decay=0.01,
-            clip_gradient=0.1,
+            clip_gradient=1.0,  # Much more reasonable clipping
             frozen_keys=frozen_keys,
         ),
         
@@ -123,20 +123,20 @@ def get_config(config_string="full,multimodal"):
             learning_rate=dict(
                 name="cosine",
                 init_value=0.0,
-                peak_value=1e-7,
-                warmup_steps=5000,
+                peak_value=1e-6,  # Still conservative but 10x larger than before
+                warmup_steps=2000,  # Shorter warmup for stage 2
                 decay_steps=total_steps - stage1_steps, # remaining steps
                 end_value=0.0,
             ),
             grad_accumulation_steps=16,
             weight_decay=0.01,
-            clip_gradient=0.1,
+            clip_gradient=1.0,  # Consistent clipping
             frozen_keys=None,
             ),
         
         val_kwargs=dict(
-            val_shuffle_buffer_size=50,
-            num_val_batches=2,
+            val_shuffle_buffer_size=200,  # Increased for better validation data diversity
+            num_val_batches=5,  # More validation batches for stable metrics
         ),
         viz_kwargs=dict(
             eval_batch_size=4,
@@ -188,6 +188,11 @@ def get_config(config_string="full,multimodal"):
                 "image": None
             }
         }
+    }
+    
+    # Disable normalization adapters for stability
+    config['update_config'] = {
+        "use_input_normalization": False,
     }
 
     return ConfigDict(config)

--- a/octo/scripts/finetune.py
+++ b/octo/scripts/finetune.py
@@ -332,6 +332,11 @@ def main(_):
     timer = Timer()
     val_data_iter = None
     
+    # Early stopping variables
+    best_val_loss = float('inf')
+    val_loss_increases = 0
+    early_stop_patience = 5  # Stop if validation loss increases for 5 consecutive evaluations
+    
     for i in tqdm.tqdm(range(int(config["num_steps"])), total=int(config["num_steps"]), dynamic_ncols=True):
         
         # Staged Training Transition Check
@@ -469,6 +474,24 @@ def main(_):
             # Aggregate and log the metrics
             metrics = jax.tree_map(lambda *xs: np.mean([x for x in xs]), *metrics)
             wandb.log({"validation": metrics}, step=i)
+            
+            # Early stopping check
+            current_val_loss = float(metrics.get('loss', metrics.get('action_loss', float('inf'))))
+            if current_val_loss < best_val_loss:
+                best_val_loss = current_val_loss
+                val_loss_increases = 0
+                logging.info(f"✅ New best validation loss: {best_val_loss:.6f}")
+            else:
+                val_loss_increases += 1
+                logging.warning(f"⚠️ Validation loss increased ({val_loss_increases}/{early_stop_patience}): {current_val_loss:.6f} > {best_val_loss:.6f}")
+                
+                if val_loss_increases >= early_stop_patience:
+                    logging.error(f"🛑 Early stopping triggered! Validation loss increased {early_stop_patience} times consecutively.")
+                    logging.error(f"   Best val loss: {best_val_loss:.6f}, Current: {current_val_loss:.6f}")
+                    if save_dir:
+                        save_callback(train_state, i + 1)
+                        logging.info(f"💾 Saved model before early stopping at step {i + 1}")
+                    break
             
             # log_memory_usage(i, "AFTER validation: ")
             gc.collect()


### PR DESCRIPTION
Adjusts training hyperparameters, disables custom normalization, and adds early stopping to improve Octo finetuning stability.

The previous finetuning setup suffered from aggressive gradient clipping, overly conservative stage 2 learning rates, and a custom normalization layer that introduced instability. Additionally, data pipeline settings were too restrictive. These changes aim to provide a more robust training environment by addressing these issues and adding early stopping for better control.

---
<a href="https://cursor.com/background-agent?bcId=bc-aae209b4-2b42-498c-9109-b0a8f87d6450">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aae209b4-2b42-498c-9109-b0a8f87d6450">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

