### PR TITLE
Verify ONNX dataset preprocessing against evaluation

### DIFF
--- a/octo/octo/utils/visualization_lib.py
+++ b/octo/octo/utils/visualization_lib.py
@@ -546,8 +546,17 @@ class WandBFigure:
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.canvas.draw()
-        out_image = np.frombuffer(self.canvas.tostring_rgb(), dtype="uint8")
-        self.image = out_image.reshape(self.fig.canvas.get_width_height()[::-1] + (3,))
+        # Compatibility with newer Matplotlib where tostring_rgb may be removed
+        width, height = self.fig.canvas.get_width_height()
+        try:
+            # Preferred path in older Matplotlib
+            buf = self.canvas.tostring_rgb()
+            arr = np.frombuffer(buf, dtype=np.uint8).reshape(height, width, 3)
+        except AttributeError:
+            # Fallback for newer Matplotlib: use RGBA buffer and drop alpha
+            buf = self.canvas.buffer_rgba()
+            arr = np.frombuffer(buf, dtype=np.uint8).reshape(height, width, 4)[..., :3]
+        self.image = arr
         plt.close(self.fig)
 
 


### PR DESCRIPTION
Update Matplotlib image extraction in `WandBFigure` to support newer versions.

The `canvas.tostring_rgb()` method was removed in recent Matplotlib versions, causing an `AttributeError` during visualization callbacks. This change adds a fallback to `canvas.buffer_rgba()` to ensure compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-546ba75f-ce63-4aab-bc76-b09fbce5936d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-546ba75f-ce63-4aab-bc76-b09fbce5936d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

