### PR TITLE
Inspect and adapt vggt onnx model for multi-layer features

### DIFF
--- a/scripts/inspect_vggt_onnx.py
+++ b/scripts/inspect_vggt_onnx.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import sys
+import glob
+import json
+from typing import Any, Dict, List, Optional
+
+
+def _install_if_missing(packages: List[str]) -> None:
+    """Best-effort install of required packages if missing."""
+    import importlib
+    missing = []
+    for pkg in packages:
+        try:
+            importlib.import_module(pkg)
+        except Exception:
+            missing.append(pkg)
+    if missing:
+        import subprocess
+        cmd = [sys.executable, "-m", "pip", "install", "--upgrade", *missing]
+        try:
+            subprocess.check_call(cmd)
+        except Exception as exc:
+            print(f"[WARN] Failed to auto-install {missing}: {exc}")
+
+
+def _safe_shape_proto_to_list(type_proto) -> List[Optional[int]]:
+    dims: List[Optional[int]] = []
+    if type_proto is None:
+        return dims
+    try:
+        shape = type_proto.tensor_type.shape
+        for d in shape.dim:
+            if d.dim_value:
+                dims.append(int(d.dim_value))
+            elif d.dim_param:
+                dims.append(None)
+            else:
+                dims.append(None)
+    except Exception:
+        pass
+    return dims
+
+
+def _dtype_from_onnx_type(elem_type: str) -> str:
+    # elem_type example: 'tensor(float16)'
+    open_paren = elem_type.find("(")
+    close_paren = elem_type.find(")")
+    if open_paren != -1 and close_paren != -1:
+        return elem_type[open_paren + 1:close_paren]
+    return elem_type
+
+
+def find_onnx_file(path: str) -> str:
+    """Return a concrete .onnx file path. If a directory is provided, pick the first matching file."""
+    if os.path.isfile(path):
+        return path
+    if os.path.isdir(path):
+        # Prefer common file names
+        preferred = [
+            os.path.join(path, "vggt_fp16.onnx"),
+            os.path.join(path, "model.onnx"),
+        ]
+        for p in preferred:
+            if os.path.isfile(p):
+                return p
+        matches = sorted(glob.glob(os.path.join(path, "*.onnx")))
+        if matches:
+            return matches[0]
+    raise FileNotFoundError(f"No .onnx file found at {path}")
+
+
+def describe_model_graph(onnx_model: "onnx.ModelProto") -> Dict[str, Any]:
+    g = onnx_model.graph
+    outputs: List[Dict[str, Any]] = []
+    for o in g.output:
+        outputs.append({
+            "name": o.name,
+            "shape": _safe_shape_proto_to_list(o.type),
+            "elem_type": getattr(o.type.tensor_type, "elem_type", None),
+        })
+    inputs: List[Dict[str, Any]] = []
+    for i in g.input:
+        inputs.append({
+            "name": i.name,
+            "shape": _safe_shape_proto_to_list(i.type),
+            "elem_type": getattr(i.type.tensor_type, "elem_type", None),
+        })
+    return {"inputs": inputs, "outputs": outputs}
+
+
+def try_infer(model_path: str, num_images: int = 2, height: int = 518, width: int = 518) -> Dict[str, Any]:
+    import numpy as np
+    import onnxruntime as ort
+
+    sess_opts = ort.SessionOptions()
+    providers = [
+        ("CUDAExecutionProvider", {}),
+        ("CPUExecutionProvider", {}),
+    ]
+    session = ort.InferenceSession(model_path, sess_options=sess_opts, providers=[p[0] for p in providers])
+
+    input_meta = session.get_inputs()[0]
+    input_name = input_meta.name
+    input_type = input_meta.type  # e.g., 'tensor(float16)'
+    dtype_name = _dtype_from_onnx_type(input_type)
+
+    np_dtype = {
+        "float16": np.float16,
+        "float": np.float32,
+        "float32": np.float32,
+        "double": np.float64,
+    }.get(dtype_name, np.float32)
+
+    # Expecting [S, 3, H, W]
+    dummy = np.random.rand(num_images, 3, height, width).astype(np_dtype)
+
+    outputs = session.run(None, {input_name: dummy})
+    output_names = [o.name for o in session.get_outputs()]
+    result = {name: (getattr(arr, "shape", None)) for name, arr in zip(output_names, outputs)}
+    return {
+        "providers": session.get_providers(),
+        "input_name": input_name,
+        "input_dtype": dtype_name,
+        "output_shapes": result,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Inspect VGGT ONNX model for available outputs and shapes.")
+    parser.add_argument("path", help="Path to .onnx file or directory containing it")
+    parser.add_argument("--num-images", type=int, default=2, help="Number of images for a dry run inference")
+    parser.add_argument("--height", type=int, default=518, help="Input height for dummy data")
+    parser.add_argument("--width", type=int, default=518, help="Input width for dummy data")
+    parser.add_argument("--no-run", action="store_true", help="Only print graph IO, skip inference")
+    args = parser.parse_args()
+
+    # Ensure runtime dependencies are present
+    _install_if_missing(["onnx", "onnxruntime"])
+
+    import onnx
+
+    onnx_path = find_onnx_file(args.path)
+    print(f"[INFO] Using ONNX model: {onnx_path}")
+
+    model = onnx.load(onnx_path)
+    io_desc = describe_model_graph(model)
+    print("[INFO] Graph IO summary (dim None means dynamic/unknown):")
+    print(json.dumps(io_desc, indent=2))
+
+    # Heuristic check for desired feature outputs
+    desired_feature_dims = {2048}
+    found_feature_like = False
+    for out in io_desc.get("outputs", []):
+        shape = out.get("shape", [])
+        if len(shape) >= 2 and any(d in desired_feature_dims for d in shape if isinstance(d, int)):
+            found_feature_like = True
+            break
+
+    if not args.no_run:
+        try:
+            run_info = try_infer(onnx_path, num_images=args.num_images, height=args.height, width=args.width)
+            print("[INFO] Inference output shapes:")
+            print(json.dumps(run_info, indent=2))
+        except Exception as exc:
+            print(f"[WARN] Inference run failed: {exc}")
+
+    # Conclusion message regarding feature availability
+    if found_feature_like:
+        print("[NOTE] Found outputs whose dimensions include 2048. Inspect the names above.")
+    else:
+        print("[NOTE] No outputs appear to expose token features (e.g., 2048-dim). Current model likely does not export per-layer tokens.")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/vggt-onnx/export_vggt_features.py
+++ b/vggt-onnx/export_vggt_features.py
@@ -1,0 +1,58 @@
+import os
+import torch
+
+from vggt.models.vggt import VGGT
+from vggt.utils.load_fn import load_and_preprocess_images
+from vggt.models.feature_export import VGGTAllLayersFeatures, VGGTSelectedLayersFeatures
+
+
+def main() -> None:
+    os.makedirs("onnx_fp16_features", exist_ok=True)
+
+    device = "cpu"
+    base = VGGT.from_pretrained("facebook/VGGT-1B").to(device)
+
+    image_names = [os.path.join("vggt", "examples", "kitchen", "images", f"{i:02}.png") for i in [0, 1]]
+    images = load_and_preprocess_images(image_names, "pad").to(device)
+
+    input_names = ["input_images"]
+
+    # Case 1: all 24 layers -> output [24, P, 2048]
+    model_all = VGGTAllLayersFeatures(base).to(device)
+    output_names_all = ["all_layer_features"]
+
+    # Case 2: selected layers [3, 10, 16, 22] (0-based) -> [4, P, 2048]
+    selected_indices = [3, 10, 16, 22]
+    model_sel = VGGTSelectedLayersFeatures(base, selected_indices).to(device)
+    output_names_sel = ["selected_layer_features"]
+
+    with torch.no_grad():
+        with torch.amp.autocast(device, dtype=torch.float16):
+            # Export all-layers
+            torch.onnx.export(
+                model_all,
+                images,
+                "onnx_fp16_features/vggt_all_layers_fp16.onnx",
+                input_names=input_names,
+                output_names=output_names_all,
+                dynamic_axes={
+                    "input_images": {0: "num_images"},
+                },
+            )
+
+            # Export selected-layers
+            torch.onnx.export(
+                model_sel,
+                images,
+                "onnx_fp16_features/vggt_selected_layers_fp16.onnx",
+                input_names=input_names,
+                output_names=output_names_sel,
+                dynamic_axes={
+                    "input_images": {0: "num_images"},
+                },
+            )
+
+
+if __name__ == "__main__":
+    main()
+

--- a/vggt-onnx/vggt/vggt/models/feature_export.py
+++ b/vggt-onnx/vggt/vggt/models/feature_export.py
@@ -1,0 +1,68 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# Thin wrappers around VGGT to expose per-layer token features for ONNX export.
+
+from typing import List, Sequence
+
+import torch
+import torch.nn as nn
+
+
+class VGGTAllLayersFeatures(nn.Module):
+    """
+    Wrapper that returns concatenated per-layer token features of shape [D, P, 2C].
+
+    Notes:
+    - Uses only the first batch index and first sequence index to match dataset expectations.
+    - D equals aggregator.depth (typically 24).
+    - P equals number of tokens per frame (camera + register + patch tokens).
+    - The channel dimension is 2C due to frame/global concatenation inside the aggregator.
+    """
+
+    def __init__(self, backbone: nn.Module):
+        super().__init__()
+        self.backbone = backbone
+
+    def forward(self, images: torch.Tensor) -> torch.Tensor:
+        # Accept [S, 3, H, W] or [B, S, 3, H, W]
+        if images.dim() == 4:
+            images = images.unsqueeze(0)
+        assert images.dim() == 5, "Expected input of shape [B, S, 3, H, W] or [S, 3, H, W]"
+
+        aggregated_tokens_list, _ = self.backbone.aggregator(images)
+        # aggregated_tokens_list: list of tensors [B, S, P, 2C], length D
+
+        # Select first batch and first sequence item for export; shape -> [P, 2C]
+        per_layer: List[torch.Tensor] = [t[0, 0, :, :] for t in aggregated_tokens_list]
+        # Stack into [D, P, 2C]
+        return torch.stack(per_layer, dim=0)
+
+
+class VGGTSelectedLayersFeatures(nn.Module):
+    """
+    Wrapper that returns selected per-layer token features of shape [K, P, 2C].
+
+    layer_indices are 0-based indices into the aggregator depth.
+    """
+
+    def __init__(self, backbone: nn.Module, layer_indices: Sequence[int]):
+        super().__init__()
+        self.backbone = backbone
+        self.register_buffer("layer_indices_tensor", torch.tensor(list(layer_indices), dtype=torch.long))
+
+    def forward(self, images: torch.Tensor) -> torch.Tensor:
+        # Accept [S, 3, H, W] or [B, S, 3, H, W]
+        if images.dim() == 4:
+            images = images.unsqueeze(0)
+        assert images.dim() == 5, "Expected input of shape [B, S, 3, H, W] or [S, 3, H, W]"
+
+        aggregated_tokens_list, _ = self.backbone.aggregator(images)
+        # aggregated_tokens_list: list of tensors [B, S, P, 2C], length D
+
+        selected = []
+        for idx in self.layer_indices_tensor.tolist():
+            t = aggregated_tokens_list[idx]
+            selected.append(t[0, 0, :, :])  # [P, 2C]
+        return torch.stack(selected, dim=0)  # [K, P, 2C]
+


### PR DESCRIPTION
Add ONNX export for VGGT models to output per-layer feature maps, supporting all layers or a selected subset.

The existing VGGT ONNX export only provided the final layer's feature map. This PR introduces new model wrappers (`VGGTAllLayersFeatures`, `VGGTSelectedLayersFeatures`) and an export script (`export_vggt_features.py`) to generate ONNX models that output feature maps from either all 24 layers or a specified subset of 4 layers (4th, 11th, 17th, 23rd), addressing the need for multi-layer feature access. An inspection script (`inspect_vggt_onnx.py`) is also included for verifying ONNX model outputs.

---
<a href="https://cursor.com/background-agent?bcId=bc-6fb385a8-9d1c-4be8-b8b2-1104aefb45d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6fb385a8-9d1c-4be8-b8b2-1104aefb45d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

