### PR TITLE
Check input normalization during evaluation

### DIFF
--- a/evaluation/scripts/run_libero_eval.py
+++ b/evaluation/scripts/run_libero_eval.py
@@ -321,24 +321,14 @@ def prepare_observation(obs):
 
 def process_action(action, model_family, action_mean=None, action_std=None):
     """Process action before sending to environment."""
-    # For OpenVLA, the dataset gripper is [0,1] so normalize and invert
     if model_family == "openvla":
         action = normalize_gripper_action(action, binarize=True)
         action = invert_gripper_action(action)
+        return action
     elif model_family == "octo":
-        if action_mean is None or action_std is None:
-            raise ValueError("Action statistics (mean, std) must be provided for Octo model evaluation!")
-            
-        # The model outputs a normalized action. Let's un-normalize it.
-        # Make sure the shapes match. The stats are for 7-dim actions.
-        action_mean = action_mean[:action.shape[-1]]
-        action_std = action_std[:action.shape[-1]]
-        
-        unnormalized_action = (action * action_std) + action_mean
-        return unnormalized_action
-    
+        # Octo actions are already un-normalized internally via model.sample_actions
+        return np.asarray(action, dtype=np.float32)
     else:
-        # Fallback for other models if needed
         return np.clip(np.asarray(action, dtype=np.float32), -1.0, 1.0)
 
 

--- a/evaluation/scripts/run_libero_eval_vggt.py
+++ b/evaluation/scripts/run_libero_eval_vggt.py
@@ -364,24 +364,14 @@ def prepare_observation(obs):
 
 def process_action(action, model_family, action_mean=None, action_std=None):
     """Process action before sending to environment."""
-    # For OpenVLA, the dataset gripper is [0,1] so normalize and invert
     if model_family == "openvla":
         action = normalize_gripper_action(action, binarize=True)
         action = invert_gripper_action(action)
+        return action
     elif model_family == "octo":
-        if action_mean is None or action_std is None:
-            raise ValueError("Action statistics (mean, std) must be provided for Octo model evaluation!")
-            
-        # The model outputs a normalized action. Let's un-normalize it.
-        # Make sure the shapes match. The stats are for 7-dim actions.
-        action_mean = action_mean[:action.shape[-1]]
-        action_std = action_std[:action.shape[-1]]
-        
-        unnormalized_action = (action * action_std) + action_mean
-        return unnormalized_action
-    
+        # Octo actions are already un-normalized internally via model.sample_actions
+        return np.asarray(action, dtype=np.float32)
     else:
-        # Fallback for other models if needed
         return np.clip(np.asarray(action, dtype=np.float32), -1.0, 1.0)
 
 

--- a/evaluation/scripts/run_libero_eval_vggt_torch.py
+++ b/evaluation/scripts/run_libero_eval_vggt_torch.py
@@ -312,13 +312,10 @@ def process_action(action, model_family, action_mean=None, action_std=None):
     if model_family == "openvla":
         action = normalize_gripper_action(action, binarize=True)
         action = invert_gripper_action(action)
+        return action
     elif model_family == "octo":
-        if action_mean is None or action_std is None:
-            raise ValueError("Action statistics (mean, std) must be provided for Octo model evaluation!")
-        action_mean = action_mean[:action.shape[-1]]
-        action_std = action_std[:action.shape[-1]]
-        unnormalized_action = (action * action_std) + action_mean
-        return unnormalized_action
+        # Octo actions are already un-normalized internally via model.sample_actions
+        return np.asarray(action, dtype=np.float32)
     else:
         return np.clip(np.asarray(action, dtype=np.float32), -1.0, 1.0)
 

--- a/evaluation/supporting_files/robot_utils.py
+++ b/evaluation/supporting_files/robot_utils.py
@@ -297,8 +297,13 @@ def get_action(
         # Construct task from text without touching its representation
         task = model.create_tasks(texts=[task_label])
 
-        # Sample action
-        action = model.sample_actions(observation, task, rng=jax.random.PRNGKey(0))
+        # Sample action with internal un-normalization (uses checkpoint stats + mask)
+        action = model.sample_actions(
+            observation,
+            task,
+            unnormalization_statistics=model.dataset_statistics["action"],
+            rng=jax.random.PRNGKey(0),
+        )
 
         # Convert to numpy and normalize output to a list of 7D steps
         arr = np.array(action)


### PR DESCRIPTION
Update Octo evaluation to use the model's internal action un-normalization.

This fixes an inconsistency where evaluation scripts were incorrectly un-normalizing actions (especially the gripper dimension), leading to 0% success rates. The model now handles action un-normalization internally using the correct dataset statistics and masks, ensuring consistency with training.

---
<a href="https://cursor.com/background-agent?bcId=bc-619af1dc-2f52-4ed3-ad60-ab937e48ee4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-619af1dc-2f52-4ed3-ad60-ab937e48ee4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

