### PR TITLE
Optimize vggt online fine-tuning speed

### DIFF
--- a/octo/scripts/configs/config_vggt.py
+++ b/octo/scripts/configs/config_vggt.py
@@ -32,9 +32,9 @@ def get_config(config_string="full,multimodal"):
         "standardize_fn": ModuleSpec.create(
                 "octo.data.utils.data_utils:standardize_libero_vggt"
         ),
-        # If the default data loading speed is too slow, try these:
-        # "num_parallel_reads": 8,  # for reading from disk / GCS
-        # "num_parallel_calls": 16,  # for initial dataset construction
+        # Parallelism knobs for faster data loading
+        "num_parallel_reads": 8,   # for reading from disk / GCS
+        "num_parallel_calls": 16,  # for initial dataset construction
     }
 
     if mode == "full":


### PR DESCRIPTION
Increase data loading parallelism in `config_vggt.py` to improve training speed by reducing input stalls.

---
<a href="https://cursor.com/background-agent?bcId=bc-5acc2908-f0bd-411e-834e-b744633c556c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5acc2908-f0bd-411e-834e-b744633c556c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

